### PR TITLE
adding ISO 8601 format (closes #37)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,12 @@
+2016-12-14  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/anytime.cpp (sformats[]): Add ISO8601 format
+
+	* tests/allFormats.R: Tests for ISO8601 format
+
 2016-12-13  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Release 0.1.2 
+	* DESCRIPTION (Version, Date): Release 0.1.2
 
 2016-12-06  Dirk Eddelbuettel  <edd@debian.org>
 
@@ -15,7 +21,7 @@
 
 2016-12-04  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll format and date
+	* DESCRIPTION (Version, Date): Roll version and date
 
 	* src/anytime.cpp (stringSplitter): Correct small oversight and split
 	on actual 'spliton' argument

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,13 @@
 \newcommand{\ghpr}{\href{https://github.com/eddelbuettel/anytime/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/eddelbuettel/anytime/issues/#1}{##1}}
 
+\section{Changes in anytime version 0.1.3 (2017-xx-yy)}{
+  \itemize{
+    \item ISO 8601 is now recognised, but the timezone information is
+    not parsed by Boost Date_Time (PR \ghpr{38} closing \ghit{37}) 
+  }
+}
+
 \section{Changes in anytime version 0.1.2 (2016-12-13)}{
   \itemize{
     \item The (internal) string processing and splitting now uses Boost

--- a/src/anytime.cpp
+++ b/src/anytime.cpp
@@ -70,6 +70,10 @@ const std::string sformats[] = {
 
     // see RFC 822 and standard Unix use eg mail headers (but no TZ or UTC offset on input :-/ )
     "%a %d %b %Y %H:%M:%S%F", 
+
+    // See the Boost documentation, tz specifications (%q %Q %z %Z) are _ignored_ on input
+    // http://www.boost.org/doc/libs/1_62_0/doc/html/date_time/date_time_io.html#date_time.time_input_facet
+    "%Y-%m-%d %H:%M:%S%Z",      
     
     "%Y-%m-%d",
     "%Y%m%d",

--- a/tests/allFormats.R
+++ b/tests/allFormats.R
@@ -41,6 +41,11 @@ anytime(c("Thu Sep 01 10:11:12 2016", "Thu Sep 01 10:11:12.345678 2016"))
 cat("\n")
 anytime(c("Thu 01 Sep 2016 10:11:12", "Thu 01 Sep 2016 10:11:12.345678"))
 
+cat("\n") # ISO 8601 variants, note that TZ field is always ignored, see Boost documentation
+anytime(c("2016-09-01T10:11:12-05:00", "2016-09-01T10:11:12.345678-05:00"))
+anytime(c("2016-09-01T10:11:12-0500",  "2016-09-01T10:11:12.345678-0500"))
+anytime(c("2016-09-01T10:11:12 CDT",   "2016-09-01T10:11:12.345678 CDT"))
+
 cat("\n")
 anytime(c("2016-09-01", "20160901", "09/01/2016", "09-01-2016"))
 


### PR DESCRIPTION
Note that Boost documentation states that the tz info is ignored on input