### PR TITLE
Named argument in cpp call to Sys.setenv()

### DIFF
--- a/R/anytime.R
+++ b/R/anytime.R
@@ -175,7 +175,7 @@ anytime <- function(x, tz=getTZ(), asUTC=FALSE, useR=FALSE,
         x <- as.character(x)
     }
 
-    anytime_cpp(x, tz=tz, asUTC=asUTC, useR=useR, oldHeuristic=oldHeuristic)
+    anytime_cpp(x, tz=tz, asUTC=asUTC, asDate=FALSE, useR=useR, oldHeuristic=oldHeuristic)
 }
 
 ##' @rdname anytime

--- a/src/anytime.cpp
+++ b/src/anytime.cpp
@@ -342,7 +342,7 @@ double r_stringToTime(const std::string s, const std::string tz,
     }
 #ifdef _WIN32
     Rcpp::Function f("Sys.setenv");
-    f("TZ", (oldtz == nullptr ? "" : oldtz), 1);
+    f(Rcpp::Named("TZ") = (oldtz == nullptr ? "" : oldtz));
 #else
     setenv("TZ", (oldtz == nullptr ? "" : oldtz), 1);
 #endif


### PR DESCRIPTION
- fixes #94
- also mentions all arguments in `anytime_cpp`