### PR TITLE
small typo fixes (plus a bit of roxygen chaff)

### DIFF
--- a/R/anytime.R
+++ b/R/anytime.R
@@ -29,7 +29,7 @@
 ##' A number of fixed formats are tried in succession. These include
 ##' the standard ISO format \sQuote{YYYY-MM-DD HH:MM:SS} as well as
 ##' different local variants including several forms popular in the
-##' United States.  Two-digits years and clearly ambigous formats such
+##' United States.  Two-digit years and clearly ambiguous formats such
 ##' as \sQuote{03/04/05} are ignored.  In the case of parsing failure
 ##' a \code{NA} value is returned.
 ##'
@@ -39,14 +39,14 @@
 ##'
 ##' @section Notes:
 ##' By default, the (internal) conversion to (fractional) seconds since the epoch is
-##' relative to the locatime of this system, and therefore not completely
+##' relative to the local time of this system, and therefore not completely
 ##' independent of the settings of the local system. This is to strike a
 ##' balance between ease of use and functionality.  A more-full featured
 ##' conversion could be possibly be added with support for arbitrary
 ##' reference times, but this is (at least) currently outside the scope of
 ##' this package. See the \pkg{RcppCCTZ} package which offers some
 ##' timezone-shifting and differencing functionality. As of version 0.0.5 one
-##' can also parse relative to UTC avoiding the localtime issue,
+##' can also parse relative to UTC avoiding the local time issue.
 ##'
 ##' Times and timezones can be tricky. This package offers a heuristic approach,
 ##' it is likely that some input formats may not be parsed, or worse, be parsed
@@ -186,7 +186,7 @@
 ##' anytime("2001-02-03 04:05:06")
 ##' ## adjust parsed time to given TZ argument
 ##' anytime("2001-02-03 04:05:06", tz="America/Los_Angeles")
-##' ## somewhat equvalent base R functionality
+##' ## somewhat equivalent base R functionality
 ##' format(anytime("2001-02-03 04:05:06"), tz="America/Los_Angeles")
 anytime <- function(x, tz = getTZ(), asUTC = FALSE,
                     useR = getOption("anytimeUseRConversions", FALSE),

--- a/man/anytime.Rd
+++ b/man/anytime.Rd
@@ -7,20 +7,37 @@
 \alias{utcdate}
 \title{Parse POSIXct or Date objects from input data}
 \usage{
-anytime(x, tz = getTZ(), asUTC = FALSE,
+anytime(
+  x,
+  tz = getTZ(),
+  asUTC = FALSE,
   useR = getOption("anytimeUseRConversions", FALSE),
   oldHeuristic = getOption("anytimeOldHeuristic", FALSE),
-  calcUnique = FALSE)
+  calcUnique = FALSE
+)
 
-anydate(x, tz = getTZ(), asUTC = FALSE,
-  useR = getOption("anytimeUseRConversions", FALSE), calcUnique = FALSE)
+anydate(
+  x,
+  tz = getTZ(),
+  asUTC = FALSE,
+  useR = getOption("anytimeUseRConversions", FALSE),
+  calcUnique = FALSE
+)
 
-utctime(x, tz = getTZ(), useR = getOption("anytimeUseRConversions", FALSE),
+utctime(
+  x,
+  tz = getTZ(),
+  useR = getOption("anytimeUseRConversions", FALSE),
   oldHeuristic = getOption("anytimeOldHeuristic", FALSE),
-  calcUnique = FALSE)
+  calcUnique = FALSE
+)
 
-utcdate(x, tz = getTZ(), useR = getOption("anytimeUseRConversions", FALSE),
-  calcUnique = FALSE)
+utcdate(
+  x,
+  tz = getTZ(),
+  useR = getOption("anytimeUseRConversions", FALSE),
+  calcUnique = FALSE
+)
 }
 \arguments{
 \item{x}{A vector of type character, integer or numeric with date(time)
@@ -76,7 +93,7 @@ A timezone can be set, if none is supplied \sQuote{UTC} is set.
 A number of fixed formats are tried in succession. These include
 the standard ISO format \sQuote{YYYY-MM-DD HH:MM:SS} as well as
 different local variants including several forms popular in the
-United States.  Two-digits years and clearly ambigous formats such
+United States.  Two-digit years and clearly ambiguous formats such
 as \sQuote{03/04/05} are ignored.  In the case of parsing failure
 a \code{NA} value is returned.
 
@@ -87,14 +104,14 @@ has not been enabled.
 \section{Notes}{
 
 By default, the (internal) conversion to (fractional) seconds since the epoch is
-relative to the locatime of this system, and therefore not completely
+relative to the local time of this system, and therefore not completely
 independent of the settings of the local system. This is to strike a
 balance between ease of use and functionality.  A more-full featured
 conversion could be possibly be added with support for arbitrary
 reference times, but this is (at least) currently outside the scope of
 this package. See the \pkg{RcppCCTZ} package which offers some
 timezone-shifting and differencing functionality. As of version 0.0.5 one
-can also parse relative to UTC avoiding the localtime issue,
+can also parse relative to UTC avoiding the local time issue.
 
 Times and timezones can be tricky. This package offers a heuristic approach,
 it is likely that some input formats may not be parsed, or worse, be parsed
@@ -204,7 +221,7 @@ utcdate(times)
 anytime("2001-02-03 04:05:06")
 ## adjust parsed time to given TZ argument
 anytime("2001-02-03 04:05:06", tz="America/Los_Angeles")
-## somewhat equvalent base R functionality
+## somewhat equivalent base R functionality
 format(anytime("2001-02-03 04:05:06"), tz="America/Los_Angeles")
 }
 \references{

--- a/man/anytime.Rd
+++ b/man/anytime.Rd
@@ -7,37 +7,20 @@
 \alias{utcdate}
 \title{Parse POSIXct or Date objects from input data}
 \usage{
-anytime(
-  x,
-  tz = getTZ(),
-  asUTC = FALSE,
+anytime(x, tz = getTZ(), asUTC = FALSE,
   useR = getOption("anytimeUseRConversions", FALSE),
   oldHeuristic = getOption("anytimeOldHeuristic", FALSE),
-  calcUnique = FALSE
-)
+  calcUnique = FALSE)
 
-anydate(
-  x,
-  tz = getTZ(),
-  asUTC = FALSE,
-  useR = getOption("anytimeUseRConversions", FALSE),
-  calcUnique = FALSE
-)
+anydate(x, tz = getTZ(), asUTC = FALSE,
+  useR = getOption("anytimeUseRConversions", FALSE), calcUnique = FALSE)
 
-utctime(
-  x,
-  tz = getTZ(),
-  useR = getOption("anytimeUseRConversions", FALSE),
+utctime(x, tz = getTZ(), useR = getOption("anytimeUseRConversions", FALSE),
   oldHeuristic = getOption("anytimeOldHeuristic", FALSE),
-  calcUnique = FALSE
-)
+  calcUnique = FALSE)
 
-utcdate(
-  x,
-  tz = getTZ(),
-  useR = getOption("anytimeUseRConversions", FALSE),
-  calcUnique = FALSE
-)
+utcdate(x, tz = getTZ(), useR = getOption("anytimeUseRConversions", FALSE),
+  calcUnique = FALSE)
 }
 \arguments{
 \item{x}{A vector of type character, integer or numeric with date(time)
@@ -93,7 +76,7 @@ A timezone can be set, if none is supplied \sQuote{UTC} is set.
 A number of fixed formats are tried in succession. These include
 the standard ISO format \sQuote{YYYY-MM-DD HH:MM:SS} as well as
 different local variants including several forms popular in the
-United States.  Two-digit years and clearly ambiguous formats such
+United States.  Two-digits years and clearly ambigous formats such
 as \sQuote{03/04/05} are ignored.  In the case of parsing failure
 a \code{NA} value is returned.
 
@@ -104,14 +87,14 @@ has not been enabled.
 \section{Notes}{
 
 By default, the (internal) conversion to (fractional) seconds since the epoch is
-relative to the local time of this system, and therefore not completely
+relative to the locatime of this system, and therefore not completely
 independent of the settings of the local system. This is to strike a
 balance between ease of use and functionality.  A more-full featured
 conversion could be possibly be added with support for arbitrary
 reference times, but this is (at least) currently outside the scope of
 this package. See the \pkg{RcppCCTZ} package which offers some
 timezone-shifting and differencing functionality. As of version 0.0.5 one
-can also parse relative to UTC avoiding the local time issue.
+can also parse relative to UTC avoiding the localtime issue,
 
 Times and timezones can be tricky. This package offers a heuristic approach,
 it is likely that some input formats may not be parsed, or worse, be parsed
@@ -221,7 +204,7 @@ utcdate(times)
 anytime("2001-02-03 04:05:06")
 ## adjust parsed time to given TZ argument
 anytime("2001-02-03 04:05:06", tz="America/Los_Angeles")
-## somewhat equivalent base R functionality
+## somewhat equvalent base R functionality
 format(anytime("2001-02-03 04:05:06"), tz="America/Los_Angeles")
 }
 \references{


### PR DESCRIPTION
While propagating typo fixes from roxygen to .Rd, `devtools::document()` also changed the format of the 'usage' section slightly. If you want I can go back and revert those changes ...
